### PR TITLE
Update three-in-one.mdx

### DIFF
--- a/stacks-and-queues/three-in-one.mdx
+++ b/stacks-and-queues/three-in-one.mdx
@@ -85,7 +85,7 @@ print(a.pop(2)) # 7
           
           item = self.items[top]
           self.items[top] = None
-          self.tops[stack] = top - 1
+          self.tops[stack] = top
   
           return item
   ```


### PR DESCRIPTION
Hi @arpan74 
I have been studying with your exercises. They are very useful. Thank you!

Today, I found this detail and I would like to you check it.

In the method of Pop in the exercises Three in One,
`self.tops[stack] = top - 1  #HERE It must be only: "self.tops[stack] = top"`
because before We have already less 1 to top variable

~~~
def pop(self, stack):
        if stack > 2:
            raise ValueError("stack does not exist")
        top = self.tops[stack] - 1
        if top < 0 or self.items[top] == None:
            raise IndexError("pop from empty stack")
        
        item = self.items[top]
        self.items[top] = None
        self.tops[stack] = top - 1  #HERE It must be only: "self.tops[stack] = top"

        return item

~~~


If you are not sure yet. You can prove with the next code:

1. Create a representation of string within the class
~~~
    def __repr__(self):
        return f"Complete StacK: {self.items}\n" \
               f"Actual top-pointer of each sub stack: {self.tops}\n" \
               f"end-pointer of each sub stack: (fixed) {self.limits}\n"
~~~

2. Run this code:
~~~
if __name__ == "__main__":
    stack3 = ThreeStack()

    stack3.push(0, 4)  # stack 0, push 4
    stack3.push(0, 6)  # stack 0, push 6
    stack3.push(1, 5)  # stack 1, push 5
    stack3.push(2, 7)  # stack 2, push 7



    stack3.pop(0)


    print(stack3)
    stack3.push(0, 6)  # stack 0, push 6
    print(stack3)
~~~

3. You will see the number '6' replace '4' in the last push.

4. You can fix it if you change the next code line:
`self.tops[stack] = top - 1  #HERE It must be only: "self.tops[stack] = top"`

I hope to help you and others with it.
See you